### PR TITLE
Show full tox ID even when user has no bio

### DIFF
--- a/templates/tox/onemomentplease.html
+++ b/templates/tox/onemomentplease.html
@@ -19,18 +19,18 @@
                 <a href="tox:{{ record.public_key }}{{ record.pin }}{{ record.checksum }}">Click here to add {{record.name}}.</a>
                 <br><br>You can also add <b>{{ record.name }}@{{ realm }}</b> in your client.
             </p>
-            {% if record.bio %}
             <div class="user_entry">
+            {% if record.bio %}
                 <p class="quote">{{ record.bio }}</p>
                 <p class="quote_tail"></p>
                 <span class="username">
                     <b>{{ record.name }}</b><span class="de-emphasize">@{{ realm }}</span>
                 </span>
+            {% end %}
                 {% if record.pin %}
                 <p class="public_id"><b>Full Tox ID</b>: {{ record.public_key }}{{ record.pin }}{{ record.checksum }}</p>
                 {% end %}
             </div>
-            {% end %}
         </div>
         <div class="chunk barcode">
             <img src="/barcode/{{ url_escape(record.name) }}.svg">


### PR DESCRIPTION
Previously, full tox id shows only when user had bio. Makes no sense to do it this way.